### PR TITLE
Build with headless opencv

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -3,3 +3,6 @@ build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
   - "--error-overdepending"
+
+upload_channels:
+  - sfe1ed40

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,8 +1,2 @@
-# the conda-build parameters to use
-build_parameters:
-  - "--suppress-variables"
-  - "--error-overlinking"
-  - "--error-overdepending"
-
 upload_channels:
   - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,13 @@
+# ************* ATTENTION! ***************
+# version 1.9.1, build number 1 was built against opencv-python-headless, uploaded to the snowflake customer channel,
+# and not released to defaults. version 1.9.1, build number 0 was built against opencv, and released to defaults. mxnet
+# development seems to have been paused, so it's not likely that this package will be updated further. If it is, a
+# decision on how to reconcile this build-version-wise split will need to be made, based on the reason and release
+# channel for the update.
+
 {% set mxnet_version="1.9.1" %}
 {% set hash_value="cef85932e2b3caead235008473d29512b99581c07da3d10703ff5b6c1fb5bd50" %}
-{% set build_number="0" %}
+{% set build_number="1" %}
 
 
 {% set dlpack_git_hash = "3efc489b55385936531a06ff83425b719387ec63" %}
@@ -151,7 +158,7 @@ outputs:
         - mkl-devel                              # [mxnet_blas_impl == 'mkl']
         - intel-openmp                           # [mxnet_blas_impl == 'mkl']
         - openblas-devel                         # [mxnet_blas_impl == 'openblas']
-        - libopencv >=4.6                        # [not s390x]
+        - opencv-python-headless >=4.6                        # [not s390x]
         - imagecodecs                            # [win]
         - cudatoolkit {{ cudatoolkit_version }}  # ['gpu' in str(mxnet_variant_str)]
         - cudnn {{ cudnn_version }}              # ['gpu' in str(mxnet_variant_str)]
@@ -162,7 +169,7 @@ outputs:
         - {{ pin_compatible('mkl-dnn') }}        # [unix and (mxnet_blas_impl == 'mkl')]
         - {{ pin_compatible('intel-openmp') }}   # [mxnet_blas_impl == 'mkl']
         - _openmp_mutex                          # [linux]
-        - opencv >=4.6                           # [not s390x]
+        - opencv-python-headless >=4.6                           # [not s390x]
 
     test:
       commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -105,6 +105,7 @@ source:
 # Right now there is no valid win-64 configuration (no mkl). So skip it. We are mxnet_blas_impl as a workaround for conda.
 build:        # [mxnet_blas_impl == 'invalid']
   skip: true  # [mxnet_blas_impl == 'invalid']
+  skip: true  # [s390x]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -221,7 +221,7 @@ outputs:
         - setuptools
       run:
         - {{ pin_subpackage('libmxnet', exact=True) }}
-        - numpy >1.16.0,<=2.0.0
+        - {{ pin_compatible('numpy', upper_bound='1.24') }}  # mxnet uses np.bool, which was removed in numpy 1.24.0
         - requests >=2.20.0,<3
         - python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@
 # channel for the update.
 
 {% set mxnet_version="1.9.1" %}
-{% set hash_value="cef85932e2b3caead235008473d29512b99581c07da3d10703ff5b6c1fb5bd50" %}
+{% set hash_value="9927f986b2c2c8315f2ba675e050ce1f4e24e84c4692e5f0a96248876784a8a7" %}
 {% set build_number="1" %}
 
 


### PR DESCRIPTION
This is to satisfy a customer request for an mxnet which doesn't pull in qt.

See last-but-one commit for successful build tests (apart from s390x, see "omissions" below).

[Upstream](https://github.com/apache/mxnet)

Changes:

- Bump build number
- Update sha - the existing one was wrong, I suppose they released a new tarball over the top without bumping the version number?
- Depend on headless opencv
- Direct towards snowflake channel

Omissions:

- a new opencv-python-headless hasn't been built, because I didn't see the need - we already have on in snowflake channel. Please see comment at the top of meta.yaml included in this change and [jira ticket](https://anaconda.atlassian.net/browse/PKG-3548) for further details.
- No changes have been made that would be to help future maintenance. This package looks end-of-life and I'd prefer to not have to do that work so I can do something else instead. Examples: replacing setup.py with pip, or addressing remaining linter comments. Absent pinnings in host are either pinned in aggregate cbc.yaml, pinned via another package (e.g. openmp/mkl related packages), or pure python packages (e.g. requests).
- s390x seems to stall at a linking stage. Snowflake doesn't care about s390x anyway. So it's been skipped.
